### PR TITLE
Fix stop script - was failing to stop postgres

### DIFF
--- a/common/stop_processes.sh
+++ b/common/stop_processes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -x
 
 sudo /var/vcap/bosh/bin/monit
 sleep 5


### PR DESCRIPTION
With the -e switch on the bash shebang the script stops once the count
of running processes reaches zero (grep returns non-zero is no lines
match) for the first batch and as a result, postgres is never stopped.
Tested on local (non vagrant) install.

Yudai, I saw your change that addressed an issue with vagrant install - do we need to dig deeper for a compatible solution for both options?
