### PR TITLE
Enable to specify nise_bosh revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ You can customize your installation using environment variables.
 | NISE_IP_ADDRESS   | IP address to bind CF components         | install.sh, register_service_tokens.sh  | Automatically detected using `ip` command      |
 | NISE_DOMAIN       | Domain name for the devbox               | launch_nise_bosh.sh                     | *nil* (<ip_address>.xip.io)                    |
 | NISE_PASSWORD     | Password for CF components               | install.sh, launch_nise_bosh.sh         | c1oudc0w                                       |
+| NISE_BOSH_REV     | Git revision specifier [note] of nise_bosh repo | install.sh, launch_nise_bosh.sh  | *nil* (currently checked-out revision)         |
+
+[note]: Do *not* use any relative revision specifier from HEAD (e.g. `HEAD~`, `HEAD~10`, `HEAD^^`). Please use an absolute revision specifier (e.g. `123abc`, `develop`). You may use a relative revision specifier from an absolute revision specifier (e.g. `master~~`).
 
 ## Build Devbox with Vagrant
 

--- a/local/install.sh
+++ b/local/install.sh
@@ -26,6 +26,10 @@ if [ ! -d nise_bosh ]; then
 fi
 (
     cd nise_bosh
+    if [ "" != "$NISE_BOSH_REV" ]; then
+        git checkout $NISE_BOSH_REV
+    fi
+    echo Use nise_bosh of revision: `git rev-list --max-count=1 HEAD` in $0
     sudo ./bin/init
 )
 
@@ -50,7 +54,7 @@ rbenv rehash
 ./local/clone_cf_release.sh
 
 # Run
-./local/launch_nise_bosh.sh
+NISE_BOSH_REV=$NISE_BOSH_REV ./local/launch_nise_bosh.sh
 
 # Postinstall
 ./local/postinstall.sh

--- a/local/launch_nise_bosh.sh
+++ b/local/launch_nise_bosh.sh
@@ -7,6 +7,10 @@ NISE_IP_ADDRESS=${NISE_IP_ADDRESS} ./common/launch_nise_bosh.sh
 
 (
     cd nise_bosh
+    if [ "" != "$NISE_BOSH_REV" ]; then
+        git checkout $NISE_BOSH_REV
+    fi
+    echo Use nise_bosh of revision: `git rev-list --max-count=1 HEAD` in $0
     bundle install
     # Old spec format
     sudo env PATH=$PATH bundle exec ./bin/nise-bosh -y ../cf-release ../manifests/deploy.yml micro -n ${NISE_IP_ADDRESS}

--- a/vagrant/install.sh
+++ b/vagrant/install.sh
@@ -19,7 +19,7 @@ gem install bundler cf nise-bosh-vagrant --no-rdoc --no-ri
 ./vagrant/clone_cf_release.sh
 
 # Install and start
-./vagrant/launch_nise_bosh.sh
+NISE_BOSH_REV=$NISE_BOSH_REV ./vagrant/launch_nise_bosh.sh
 
 # Startup
 ./vagrant/start_processes.sh

--- a/vagrant/launch_nise_bosh.sh
+++ b/vagrant/launch_nise_bosh.sh
@@ -10,7 +10,19 @@ if [ ${NISE_IP_ADDRESS} != "192.168.10.10" ]; then
     BRIDGE_OPTION="--bridge --address=${NISE_IP_ADDRESS}"
 fi
 
-nise-bosh-vagrant ./cf-release --manifest ./manifests/deploy.yml --memory ${VAGRANT_MEMORY} --postinstall ./vagrant/postinstall.sh --install ${BRIDGE_OPTION}
+if [ "" != "$NISE_BOSH_REV" ]; then
+    if [ ! -d nise_bosh ]; then
+        git clone https://github.com/nttlabs/nise_bosh.git
+    fi
+    (
+        cd nise_bosh
+        git checkout $NISE_BOSH_REV
+        echo Use nise_bosh of revision: `git rev-list --max-count=1 HEAD` in $0
+    )
+    NISE_BOSH_PATH_OPTION="--nise ./nise_bosh"
+fi
+
+nise-bosh-vagrant ./cf-release --manifest ./manifests/deploy.yml --memory ${VAGRANT_MEMORY} --postinstall ./vagrant/postinstall.sh --install ${BRIDGE_OPTION} $NISE_BOSH_PATH_OPTION
 
 # Reboot VM once to reload kernel
 (


### PR DESCRIPTION
I occasionally have wanted to use some fixed revision of nise_bosh to run cf_nise_installer.

So I want to add an environment variable NISE_BOSH_REV to specify a revision of nise_bosh.
If it is not set, the revision currently checked-out is used.
