### PR TITLE
Fix CF_RELEASE_BRANCH to be handled properly

### DIFF
--- a/scripts/clone_cf_release.sh
+++ b/scripts/clone_cf_release.sh
@@ -15,7 +15,7 @@ if [ ! "$(ls -A cf-release)" ]; then
     (
         cd cf-release
 
-        if [ -z "${CF_RELEASE_BRANCH}" ]; then
+        if [ -n "${CF_RELEASE_BRANCH}" ]; then
             git checkout -f ${CF_RELEASE_BRANCH}
         fi
 


### PR DESCRIPTION
Current implementation omits CF_RELEASE_BRANCH even if it is set, because

```
[ -z "$CF_RELEASE_BRANCH" ]
```

returns 1.

You can easily confirm this by:

```
export CF_RELEASE_BRANCH=fix-cf-release-branch-handling
[ -z "$CF_RELEASE_BRANCH" ]
echo $?
```

Please fix it.
Thanks in advance.
