### PR TITLE
rename 'loggregator_endpoint' to 'metron_endpoint' in cf-release job templates

### DIFF
--- a/manifests/template.yml
+++ b/manifests/template.yml
@@ -237,10 +237,11 @@ properties:
     incoming_port: 13456
     outgoing_port: 48080
 
-  metron_endpoint:
+  metron_endpoint: &metron_endpoint
     shared_secret: c1oudc0w
     host: 192.168.10.10
     port: 13456
+  loggregator_endpoint: *metron_endpoint
 
   ha_proxy:
     ssl_pem: |


### PR DESCRIPTION
When I install using cf_nise_installer 'v176' tagged version, user logs from some CF components (ccng, dea_next, gorouter) are not sent to loggregator.
Root cause is renaming 'loggregator_endpoint' to 'metron_endpoint' in job templates from cf-release v176.
See: https://github.com/cloudfoundry/cf-release/commit/c0148b1438933a7221752001fe5f6fd94dd20611

But somewhat, 'dea_logging_agent' job template still use 'loggregator_endpoint' in cf-release v176.
See: https://github.com/cloudfoundry/loggregator/blob/6ee70f1da0c836e5f395839a617fcc068fdac14f/bosh/jobs/dea_logging_agent/templates/dea_logging_agent.json.erb
This loggregator bug is fixed in cf-release v177.
See: https://github.com/cloudfoundry/loggregator/blob/d6f1ecad1e2167e6f55008ea755e3c8e6fa5d160/bosh/jobs/dea_logging_agent/templates/dea_logging_agent.json.erb
