### PR TITLE
cf-release v228

### DIFF
--- a/manifests/template.yml
+++ b/manifests/template.yml
@@ -167,6 +167,8 @@ properties:
       addnew: false
       client_secret: c1oudc0w
     url: https://uaa.192.168.10.10.xip.io
+    ssl:
+      port: -1
     catalina_opts: -Xmx384m -XX:MaxPermSize=128m
     jwt:
       signing_key: |
@@ -221,14 +223,29 @@ properties:
         secret: c1oudc0w
         authorized-grant-types: client_credentials
       gorouter:
-        authorities: clients.read,clients.write,clients.admin,routing.routes.write,routing.routes.read
+        authorities: routing.routes.read
         authorized-grant-types: client_credentials,refresh_token
-        scope: openid,cloud_controller_service_permissions.read
         secret: c1oudc0w
       cc_routing:
         authorities: routing.router_groups.read
         secret: c1oudc0w
         authorized-grant-types: client_credentials
+      tcp_emitter:
+        authorities: routing.routes.write,routing.routes.read
+        authorized-grant-types: client_credentials,refresh_token
+        secret: c1oudc0w
+      tcp_router:
+        authorities: routing.routes.read
+        authorized-grant-types: client_credentials,refresh_token
+        secret: c1oudc0w
+      cf:
+        id: cf
+        override: true
+        authorized-grant-types: implicit,password,refresh_token
+        scope: cloud_controller.read,cloud_controller.write,openid,password.write,cloud_controller.admin,scim.read,scim.write,doppler.firehose,uaa.user,routing.router_groups.read
+        authorities: uaa.none
+        access-token-validity: 600
+        refresh-token-validity: 2592000
 
     scim:
       users:
@@ -323,6 +340,9 @@ properties:
 
   dropsonde:
     enabled: true
+
+  hm9000:
+    port: 5155
 
   route_registrar:
     routes:


### PR DESCRIPTION
This will pull in the cf-release at v228.  It also updates the manifests/template.yml to work with v228.  Only problem is the consul_agent will not come up as there is no consul server.  However, this does not keep the system from being usable.